### PR TITLE
fix(manifest): Remove references to missing icons

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -13,19 +13,9 @@
     "https://www.perplexity.ai/"
   ],
   "action": {
-    "default_popup": "popup.html",
-    "default_icon": {
-      "16": "images/icon16.png",
-      "48": "images/icon48.png",
-      "128": "images/icon128.png"
-    }
+    "default_popup": "popup.html"
   },
   "background": {
     "service_worker": "background.js"
-  },
-  "icons": {
-    "16": "images/icon16.png",
-    "48": "images/icon48.png",
-    "128": "images/icon128.png"
   }
 }


### PR DESCRIPTION
This commit resolves an error that occurred when loading the extension in Chrome: "Could not load icon 'images/icon16.png'".

The error was caused by references in `manifest.json` to icon files that do not exist in the repository.

The fix involves:
- Removing the `icons` and `action.default_icon` properties from `manifest.json`.
- The associated empty `images` directory was found to be not present in the repo, so no deletion was necessary.

The extension will now load without errors, using the default browser icon.