### PR TITLE
Fix: Update outdated CSS selectors for AI platforms

### DIFF
--- a/content.js
+++ b/content.js
@@ -63,7 +63,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     switch (true) {
       case url.includes('chatgpt.com'):
         fillAndClick(
-            'textarea[placeholder*="Message"]',
+            'textarea[id="prompt-textarea"]',
             'button[data-testid="send-button"]',
             prompt
         );
@@ -71,16 +71,16 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 
       case url.includes('gemini.google.com'):
         fillAndClick(
-            '.query-box [role="textbox"]',
-            'button.send-button',
+            '.ql-editor.ql-blank',
+            'button.send-btn',
             prompt
         );
         break;
 
       case url.includes('claude.ai'):
         fillAndClick(
-            'div[contenteditable="true"]',
-            'button[aria-label*="Send"]',
+            'div.ProseMirror',
+            'button[aria-label*="Send Message"]',
             prompt,
             300 // Add a 300ms delay for Claude
         );
@@ -88,7 +88,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 
       case url.includes('perplexity.ai'):
         fillAndClick(
-            'textarea[placeholder*="Ask"]',
+            'textarea[placeholder*="Ask anything..."]',
             'button[aria-label="Submit"]',
             prompt
         );


### PR DESCRIPTION
The CSS selectors used in content.js to find input fields and buttons on ChatGPT, Gemini, Claude, and Perplexity were outdated, leading to "Element not found" errors.

This patch updates the selectors to more robust and current alternatives to restore the extension's functionality.

- ChatGPT: Use ID selector for the textarea.
- Gemini: Use class selectors for the Quill editor.
- Claude: Use a class selector for the ProseMirror editor and update the button's aria-label.
- Perplexity: Update the placeholder text in the selector.