### PR TITLE
Fix: Update selectors and improve input simulation

### DIFF
--- a/content.js
+++ b/content.js
@@ -35,7 +35,8 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 
     const simulateContentEditableInput = (element, text) => {
         element.focus();
-        element.innerHTML = text;
+        // Wrap text in a paragraph tag to better support rich text editors
+        element.innerHTML = `<p>${text}</p>`;
         element.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
         element.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
     };


### PR DESCRIPTION
This commit provides a comprehensive fix for the extension's content script.

1.  Updates all CSS selectors for ChatGPT, Gemini, Claude.ai, and Perplexity.ai based on user-provided HTML, including support for French UI labels.

2.  Improves the `simulateContentEditableInput` function by wrapping the injected text in a `<p>` tag. This provides better support for modern rich text editors (like Lexical on Perplexity.ai) and fixes a bug where the input was not being detected, preventing the send button from appearing.

3.  Includes a previous fix for an "Unchecked runtime.lastError" by ensuring the `sendResponse` callback is always called on timeout.