### PR TITLE
Fix(perplexity): Update selectors for Perplexity.ai

### DIFF
--- a/content.js
+++ b/content.js
@@ -91,8 +91,8 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 
       case url.includes('perplexity.ai'):
         fillAndClick(
-            'div[id="ask-input"]',
-            'button[aria-label="Submit"]',
+            'textarea',
+            'button[aria-label*="Submit"]',
             prompt
         );
         break;


### PR DESCRIPTION
The previous selectors for Perplexity.ai were outdated, causing the extension to fail on that site. This commit updates the selectors to be more robust and less likely to break due to minor UI changes.

- The input selector is changed from `div[id="ask-input"]` to `textarea`.
- The submit button selector is changed from `button[aria-label="Submit"]` to `button[aria-label*="Submit"]` to allow for partial matches.