### PR TITLE
feat: Add support for Mistral AI

### DIFF
--- a/content.js
+++ b/content.js
@@ -102,6 +102,14 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         );
         break;
 
+      case url.includes('chat.mistral.ai'):
+        fillAndClick(
+            'textarea[placeholder="Send a message..."]',
+            'button[aria-label="Send message"]',
+            prompt
+        );
+        break;
+
       case url.includes('perplexity.ai'):
         waitForElement('div[id="ask-input"]', (input) => {
           simulatePaste(input, prompt);

--- a/popup.html
+++ b/popup.html
@@ -37,6 +37,7 @@
     <label><input type="checkbox" id="gemini" value="https://gemini.google.com/app?hl=fr" checked> Gemini</label><br>
     <label><input type="checkbox" id="claude" value="https://claude.ai/new" checked> Claude</label><br>
     <label><input type="checkbox" id="perplexity" value="https://www.perplexity.ai/" checked> Perplexity</label><br>
+    <label><input type="checkbox" id="mistral" value="https://chat.mistral.ai/chat" checked> Mistral</label><br>
   </div>
 
   <button id="submit-button">Submit</button>


### PR DESCRIPTION
This commit adds support for the Mistral AI chat website (https://chat.mistral.ai) to the extension.

- Adds a checkbox for Mistral in the extension's popup.
- Adds a new case in the content script to handle the prompt submission on the Mistral website.
- Uses the selectors `textarea[placeholder="Send a message..."]` for the input field and `button[aria-label="Send message"]` for the submit button.