### PR TITLE
fix: Update Mistral selectors for prompt submission

### DIFF
--- a/content.js
+++ b/content.js
@@ -104,9 +104,10 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 
       case url.includes('chat.mistral.ai'):
         fillAndClick(
-            'textarea[placeholder="Send a message..."]',
-            'button[aria-label="Send message"]',
-            prompt
+            'div.ProseMirror[data-placeholder*="Posez n\'importe quelle question"]',
+            'button[aria-label="Send question"]',
+            prompt,
+            300 // Add a delay for Mistral UI to update
         );
         break;
 


### PR DESCRIPTION
This commit corrects the CSS selectors used to interact with the Mistral AI chat website. The previous selectors were based on assumptions and did not work.

The new selectors are based on the actual HTML of the page, as provided by the user:
- The prompt input is now targeted with `div.ProseMirror[data-placeholder*="Posez n'importe quelle question"]`.
- The send button is now targeted with `button[aria-label="Send question"]`.

A 300ms delay has also been added to allow the UI to update after the prompt is inserted, ensuring the send button is available to be clicked.